### PR TITLE
ECR_URI取得時にprofileオプションが適用されていなかったため修正

### DIFF
--- a/bin/push-image.sh
+++ b/bin/push-image.sh
@@ -50,7 +50,7 @@ set -e
 AWS_ACCOUNT=$(aws sts get-caller-identity --profile ${AWS_PROFILE} --output text --query "Account")
 aws ecr get-login-password --region $AWS_REGION --profile ${AWS_PROFILE} | docker login --username AWS --password-stdin ${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com
 
-ECR_URI=$(aws ecr describe-repositories --repository-name "${ECR_NAME}" --output text --query 'repositories[0].repositoryUri')
+ECR_URI=$(aws ecr describe-repositories --profile ${AWS_PROFILE} --repository-name "${ECR_NAME}" --output text --query 'repositories[0].repositoryUri')
 
 $SCRIPT_DIR/build.sh
 invoke docker tag ${APP_NAME}/model:latest ${ECR_URI}:latest


### PR DESCRIPTION
## 修正対象

- bin/lib/push-image.sh

## 修正内容

- シェルの ```--profile``` オプションが効かない箇所(ECR_URIをセットするawscliコマンド)があったので、awscliコマンドの引数に ```--profile ${AWS_PROFILE}``` を追記しました。